### PR TITLE
Add containerized build for Linux-based development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+CONTAINER_RUNTIME ?= podman
+
+.PHONY: containerized
+containerized:
+	rm -rf bin/ obj/
+	${CONTAINER_RUNTIME} build -t dotnet-build -f images/Dockerfile.fedora .
+	${CONTAINER_RUNTIME} run --name runingenie-build dotnet-build sh -c "dotnet restore && dotnet publish -c Release -r win-x64"
+	${CONTAINER_RUNTIME} cp runingenie-build:/app/bin ./bin
+	${CONTAINER_RUNTIME} rm runingenie-build
+	#${CONTAINER_RUNTIME} rmi dotnet-build  # this forces a rebuild of the toolchain each time

--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -1,0 +1,6 @@
+FROM registry.fedoraproject.org/fedora:latest
+WORKDIR /app
+
+RUN dnf install -y dotnet-sdk-5.0
+
+COPY . .


### PR DESCRIPTION
This uses a Fedora-based container image to build the application

It defaults to Podman:
```
$ make containerized
```

or to use Docker
```
$ CONTAINER_RUNTIME=docker make containerized
```

The binaries are copied to the `./bin` folder as expected from a regular build