### PR TITLE
Allow to override shell and shorthand to invoke WSL shell

### DIFF
--- a/RunInGenie.csproj
+++ b/RunInGenie.csproj
@@ -11,5 +11,8 @@
     <SelfContained>false</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This fixes #2 

Still wanting to refactor this a little. If you create a file `$.json` to can set the shell with:
```json
{
  "shell": "zsh"
}
```
Note: opened this for feedback. Placed the configurationbuilder in the GetShell() function as for now I do not see a reason why not... unless of course a `distro` option is needed? Hmmmm

Note2: GetShell is very Java-like. Could be an accessor instead. What do you prefer, especially considering #4 to force another distro.